### PR TITLE
doc: log in case no var in prompt template

### DIFF
--- a/concepts/prompt.mdx
+++ b/concepts/prompt.mdx
@@ -163,6 +163,12 @@ main();
 ```
 </CodeGroup>
 
+<Warning>
+Make sure to always prepare your messages with `Prompt.format_messages` &ndash; or its
+TypeScript equivalent, even if you do not have variables to resolve. This ensures
+messages are logged properly when using our OpenAI instrumentation.
+</Warning>
+
 ### Langchain Chat Template
 
 Since Langchain has a different format for prompts, you can convert a Literal prompt to a Langchain Chat Template.


### PR DESCRIPTION
@constantinidan Let me know if its the kind of warning you expect to see in the documentation for https://linear.app/literalai/issue/ENG-1193/need-to-log-in-case-no-variable-in-prompt-template

![image](https://github.com/Chainlit/literal-docs/assets/6545903/12e01a51-cb8a-47f7-9bf4-a9027f23ad20)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Chainlit/literal-docs/39)
<!-- Reviewable:end -->
