### PR TITLE
Rename Literal and LiteralAI references to Literal AI

### DIFF
--- a/concepts/dataset.mdx
+++ b/concepts/dataset.mdx
@@ -123,8 +123,8 @@ literal_client = LiteralClient(api_key=os.getenv("LITERAL_API_KEY"))
 # option 1: add local items
 dataset_item = literal_client.api.create_dataset_item(
   dataset_id = "<DATASET_ID>", # dataset.id
-  input = { "content": "What is literal?" },
-  expected_output = { "content": "Literal is an observability solution." }
+  input = { "content": "What is Literal AI?" },
+  expected_output = { "content": "Literal AI is an observability solution." }
 )
 
 # option 2: add existing steps, runs, generations
@@ -146,8 +146,8 @@ const literalClient = new LiteralClient(process.env["LITERAL_API_KEY"]);
 // option 1: add local items
 const datasetId = "<DATASET_ID>";
 const item = {
-    input: { content: "What is literal?" },
-    expectedOutput: { content: "Literal is an observability solution." },
+    input: { content: "What is Literal AI?" },
+    expectedOutput: { content: "Literal AI is an observability solution." },
 };
 
 const start = async function() {

--- a/concepts/evaluation.mdx
+++ b/concepts/evaluation.mdx
@@ -9,7 +9,7 @@ versions perform better than previous ones. To best capture the **user experienc
 multiple steps which make up the application. As AI applications grow in complexity, they tend to chain 
 multiple steps.
 
-Literal lets you log & monitor the various steps of your LLM application. By doing so, you can continuously improve the performance of your LLM system, building the most relevant metrics:
+Literal AI lets you log & monitor the various steps of your LLM application. By doing so, you can continuously improve the performance of your LLM system, building the most relevant metrics:
 - Thread &mdash; user satisfaction, etc.
 - Agent Run &mdash; task completion, etc.
 - LLM Generation &mdash; hallucination, etc.
@@ -25,7 +25,7 @@ An example is the vanilla Retrieval Augmented Generation (RAG), which augments L
   <img src="/images/rag-thread.png" alt="A thread on a RAG application" />
 </Frame>
 
-Literal offers a compelling user/developer interface to build and interact with datasets.
+Literal AI offers a compelling user/developer interface to build and interact with datasets.
 Through `Dataset` objects, users can iterate on a parameter of the LLM system - such as prompt template, LLM provider, temperature, etc - and view its impact via Experiments. 
 
 A developer can also iterate on their prompt template and check the impact of their
@@ -43,13 +43,13 @@ promptfoo, Ragas, OpenAI Evals, LangChain Evaluators, etc.
 
 - [Prompt Iteration with **Promptfoo**](https://github.com/Chainlit/literal-cookbook/tree/main/evaluation/typescript/prompt-iteration-promptfoo):
 Our cookbook shows how a developer can leverage the `promptfoo` library in TypeScript to
-compute similarity scores and persist the results of their experiments directly on Literal. 
+compute similarity scores and persist the results of their experiments directly on Literal AI.
 - [Context Relevancy with **Ragas**](https://github.com/Chainlit/literal-cookbook/tree/main/evaluation/python): our notebook experiments on an example RAG
 application to score context relevancy.
 
-For more examples on evaluations, please browse our [Literal Cookbooks](https://github.com/Chainlit/literal-cookbook/tree/main/evaluation).
+For more examples on evaluations, please browse our [Literal AI Cookbooks](https://github.com/Chainlit/literal-cookbook/tree/main/evaluation).
 
-<Card title="Evaluation - Literal Cookbooks" icon="github" href="https://github.com/Chainlit/literal-cookbook/tree/main/evaluation">
+<Card title="Evaluation - Literal AI Cookbooks" icon="github" href="https://github.com/Chainlit/literal-cookbook/tree/main/evaluation">
 Explore additional evaluation concepts and frameworks.
 </Card>
 

--- a/concepts/generation.mdx
+++ b/concepts/generation.mdx
@@ -4,7 +4,7 @@ title: "Generation"
 
 A `Generation` is the output or answer produced by an LLM. A generation can be part of a `Step`, and contains both the input sent to an LLM and its completion. 
 
-Generations can be viewed on their own page in Literal. In a single generation, you can see all the data that was sent to and retrieved from the LLM model, which follows the Prompt template, including System messages, User messages, Assistant messages, and Tool messages.
+Generations can be viewed on their own page in Literal AI. In a single generation, you can see all the data that was sent to and retrieved from the LLM model, which follows the Prompt template, including System messages, User messages, Assistant messages, and Tool messages.
 
 You can add [Tags](/concepts/thread#tags) and [Scores](/concepts/score) to Generations. Additionally, you can add Generations to a [Dataset](/concepts/dataset), to use later on in for example Evaluation. 
 

--- a/concepts/project-roles.mdx
+++ b/concepts/project-roles.mdx
@@ -2,7 +2,7 @@
 title: Projects & Roles
 ---
 
-With the ability to create projects on Literal, you can compartmentalize different parts of your LLM Product.
+With the ability to create projects on Literal AI, you can compartmentalize different parts of your LLM Product.
 
 ### Creating & inviting members to a Project
 

--- a/concepts/run.mdx
+++ b/concepts/run.mdx
@@ -4,7 +4,7 @@ title: "Run"
 
 A `run` signifies the execution of an agent or a chain that takes multiple steps. It is a sequence of Steps, that, unlike other Step types, does not have to be part of a Thread. This is useful if you are monitoring non-conversational use cases.
 
-`Runs` are visualized as part of Thread on the `Threads` page, but they can also be viewed on their own `Runs` page on Literal. Here, all Runs are visualized, not only runs that are part of Threads. Runs have a unique ID (different from the `Thread ID`, since Runs are different from Threads). The `Steps` in a Run can be scored and tagged as usual.
+`Runs` are visualized as part of Thread on the `Threads` page, but they can also be viewed on their own `Runs` page on Literal AI. Here, all Runs are visualized, not only runs that are part of Threads. Runs have a unique ID (different from the `Thread ID`, since Runs are different from Threads). The `Steps` in a Run can be scored and tagged as usual.
 
 The example in the following image shows a Run called `Query` of a RAG chatbot agent, that Retrieves context documents and Generates an answer using a GPT-4 model.
 

--- a/concepts/thread.mdx
+++ b/concepts/thread.mdx
@@ -142,7 +142,7 @@ Finally, you can add a Step to a Dataset (6), for example for evaluation purpose
 
 ## Tags
 
-You can add tags to a Thread, [Step](/concepts/step) or [Generation](/concepts/generation). Similar to Github labels, you can use tags to filter data both from the Literal UI and the clients. Tags are shared between units (Threads, Steps and Generations). 
+You can add tags to a Thread, [Step](/concepts/step) or [Generation](/concepts/generation). Similar to Github labels, you can use tags to filter data both from the Literal AI UI and the clients. Tags are shared between units (Threads, Steps and Generations).
 
 To add a tag to a Thread or Generation, open the specific item and add the tag on the top of the window. Here, you can also add new tags. Adding tags to Steps is possible in the Step itself. 
 

--- a/concepts/user.mdx
+++ b/concepts/user.mdx
@@ -2,7 +2,7 @@
 title: User
 ---
 
-In Literal, the concept of a user is designed to seamlessly integrate with your application, allowing developers to create and manage user profiles that mirror their own application's user base.
+In Literal AI, the concept of a user is designed to seamlessly integrate with your application, allowing developers to create and manage user profiles that mirror their own application's user base.
 
 It's important to note that the concept of User only exists at the Thread level, not at the Step level.
 

--- a/get-started/installation.mdx
+++ b/get-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install the Literal client and get your API key"
+description: "Install the Literal AI client and get your API key"
 ---
 
 <CodeGroup>
@@ -13,7 +13,7 @@ npm i @literalai/client
 ```
 </CodeGroup>
 
-## Instantiate the Literal client
+## Instantiate the Literal AI client
 
 <CodeGroup>
 ```python Python

--- a/get-started/overview.mdx
+++ b/get-started/overview.mdx
@@ -2,14 +2,14 @@
 title: Overview
 ---
 
-Literal is an all in one **observability**, **evaluation** and **analytics** platform for building **production-grade LLM apps**.
+Literal AI is an all in one **observability**, **evaluation** and **analytics** platform for building **production-grade LLM apps**.
 
-It covers a wide range of use cases, from conversational applications to task automation. Literal can be used with any LLM framework, for example [Chainlit](/integrations/chainlit) and [LangChain](/integrations/langchain). It integrates well with many LLM providers, like [OpenAI](/integrations/openai), [Anthrophic and Mistral](/integrations/llm-providers).
+It covers a wide range of use cases, from conversational applications to task automation. Literal AI can be used with any LLM framework, for example [Chainlit](/integrations/chainlit) and [LangChain](/integrations/langchain). It integrates well with many LLM providers, like [OpenAI](/integrations/openai), [Anthrophic and Mistral](/integrations/llm-providers).
 
-Literal is developed by the builders of [Chainlit](https://github.com/Chainlit/chainlit), the open-source Conversational AI Python framework.
+Literal AI is developed by the builders of [Chainlit](https://github.com/Chainlit/chainlit), the open-source Conversational AI Python framework.
 
-<Frame caption="Literal Platform Example Thread">
-  <img src="/images/overview.png" alt="Literal Platform Example Thread"/>
+<Frame caption="Literal AI Platform Example Thread">
+  <img src="/images/overview.png" alt="Literal AI Platform Example Thread"/>
 </Frame>
 
 # Key Features
@@ -21,7 +21,7 @@ Literal is developed by the builders of [Chainlit](https://github.com/Chainlit/c
   icon="eye"
   color="#ea5a0c"
   href="/concepts/thread">
-  Monitor your LLM app (including steps, feedback, prompts, token consumption) in a few minutes with our SDKs. Literal provides a unified view of all your data in one place.
+  Monitor your LLM app (including steps, feedback, prompts, token consumption) in a few minutes with our SDKs. Literal AI provides a unified view of all your data in one place.
 </Card>
 
   <Card
@@ -45,7 +45,7 @@ Literal is developed by the builders of [Chainlit](https://github.com/Chainlit/c
   icon="gears"
   color="#F80061"
   href="/concepts/prompt">
-  Safely design, try, debug, version and deploy prompts directly from Literal.
+  Safely design, try, debug, version and deploy prompts directly from Literal AI.
 </Card>
 
 </CardGroup>
@@ -57,11 +57,11 @@ Literal is developed by the builders of [Chainlit](https://github.com/Chainlit/c
 <CardGroup cols={2}>
 
 <Card title="Get Started" icon="code" color="#0285c7" href="/get-started/installation">
-  Install the Literal SDK and get your API key.
+  Install the Literal AI SDK and get your API key.
 </Card>
 
 <Card title="Learn more about integrations" icon="circle" color="#ea5a0c" href="/get-started/quick-start">
-  Learn about OpenAI, LangChain and Chainlit with Literal.
+  Learn about OpenAI, LangChain and Chainlit with Literal AI.
 </Card>
 
 </CardGroup>

--- a/get-started/quick-start.mdx
+++ b/get-started/quick-start.mdx
@@ -2,11 +2,11 @@
 title: Quick Start
 ---
 
-Once you have your project setup and the Literal SDK installed, the fastest way to start logging your data is to **leverage our integrations**.
+Once you have your project setup and the Literal AI SDK installed, the fastest way to start logging your data is to **leverage our integrations**.
 
 ## Integrations
 
-Literal comes with a set of integrations with popular libraries of the GenAI field. Let us know if you want to see a new integration!
+Literal AI comes with a set of integrations with popular libraries of the GenAI field. Let us know if you want to see a new integration!
 
 
 <CardGroup cols={2}>
@@ -16,7 +16,7 @@ Literal comes with a set of integrations with popular libraries of the GenAI fie
   color="#ea5a0c"
   href="/integrations/openai">
 >
-  Learn how to monitor your OpenAI completions with Literal.
+  Learn how to monitor your OpenAI completions with Literal AI.
 </Card>
 
 <Card
@@ -24,7 +24,7 @@ title="Langchain"
 icon="circle"
 color="#0285c7"
 href="/integrations/langchain">
-  Learn how to use monitor any Langchain agent with Literal.
+  Learn how to use monitor any Langchain agent with Literal AI.
 </Card>
 
 <Card
@@ -32,7 +32,7 @@ title="Llama Index"
 icon="circle"
 color="#8b5cf6"
 href="/integrations/llama-index">
-  Learn how to use monitor your RAG pipeline with Literal.
+  Learn how to use monitor your RAG pipeline with Literal AI.
 </Card>
 
 <Card
@@ -40,7 +40,7 @@ title="HuggingFace"
 icon="circle"
 color="#eab308"
 href="/integrations/messages-server">
-  Monitor any HuggingFace model with Literal. 
+  Monitor any HuggingFace model with Literal AI.
 </Card>
 
 <Card
@@ -49,14 +49,14 @@ href="/integrations/messages-server">
   color="#dc2626"
   href="/integrations/openai-assistant">
 >
-  Learn how to monitor your OpenAI Assistants with Literal.
+  Learn how to monitor your OpenAI Assistants with Literal AI.
 </Card>
 <Card
 title="Chainlit"
 icon="circle"
 color="#F80061"
 href="/integrations/chainlit">
-  Learn how to use monitor your Chainlit application with Literal.
+  Learn how to use monitor your Chainlit application with Literal AI.
 </Card>
 
 </CardGroup>

--- a/graphql-api-reference/introduction.mdx
+++ b/graphql-api-reference/introduction.mdx
@@ -4,9 +4,9 @@ title: Introduction
 
 If you are programming in another language, you can use Literal's GraphQL API endpoint. 
 
-The API url is: `https://cloud.getliteral.ai/api/graphql`. If you follow that link, and you have previously logged into the Literal platform, you can see the GraphQL query documentation and you can make queries. The button on the top left corner leads you to the documentation (1).
+The API url is: `https://cloud.getliteral.ai/api/graphql`. If you follow that link, and you have previously logged into the Literal AI platform, you can see the GraphQL query documentation and you can make queries. The button on the top left corner leads you to the documentation (1).
 
-There are two types of GraphQL functions: `Query` and `Mutation`. Use a `Query` if you want to fetch data or information from Literal, and `Mutation` if you want add, update or delete data.
+There are two types of GraphQL functions: `Query` and `Mutation`. Use a `Query` if you want to fetch data or information from Literal AI, and `Mutation` if you want add, update or delete data.
 
 You can build queries using the `GraphiQL Explorer` (2). 
 
@@ -17,7 +17,7 @@ You can build queries using the `GraphiQL Explorer` (2).
   />
 </Frame>
 
-You can make GraphQL requests via cURL. To make a query, do a `HTTP POST` request, since all GraphQL API requests use the `POST` method. Make sure you pass your Literal API key.
+You can make GraphQL requests via cURL. To make a query, do a `HTTP POST` request, since all GraphQL API requests use the `POST` method. Make sure you pass your Literal AI API key.
 
 A query to fetch the `id` and `name` of all `Datasets` in Literal:
 

--- a/guides/agent-run.mdx
+++ b/guides/agent-run.mdx
@@ -2,8 +2,8 @@
 title: Agent Run Monitoring
 ---
 
-This code integrates an asynchronous OpenAI client with a LiteralAI client to create a conversational agent. 
-It utilizes LiteralAI's step decorators for structured logging and tool orchestration within a conversational flow. 
+This code integrates an asynchronous OpenAI client with a Literal AI client to create a conversational agent.
+It utilizes Literal AI's step decorators for structured logging and tool orchestration within a conversational flow.
 The agent can process user messages, make decisions on tool usage, and generate responses based on a predefined set of tools and a maximum iteration limit to prevent infinite loops.
 
 ```bash .env

--- a/guides/conversational-agent-fastapi.mdx
+++ b/guides/conversational-agent-fastapi.mdx
@@ -2,8 +2,8 @@
 title: Conversational Agent Monitoring - FastAPI 
 ---
 
-This code integrates an asynchronous OpenAI client with a LiteralAI client to create a conversational agent. 
-It utilizes LiteralAI's step decorators for structured logging and tool orchestration within a conversational flow. 
+This code integrates an asynchronous OpenAI client with a Literal AI client to create a conversational agent.
+It utilizes Literal AI's step decorators for structured logging and tool orchestration within a conversational flow.
 The agent can process user messages, make decisions on tool usage, and generate responses based on a predefined set of tools and a maximum iteration limit to prevent infinite loops.
 
 **This example demonstrates thread-based monitoring, allowing for detailed tracking and analysis of conversational threads.**

--- a/guides/conversational-agent.mdx
+++ b/guides/conversational-agent.mdx
@@ -2,8 +2,8 @@
 title: Conversational Agent Monitoring
 ---
 
-This code integrates an asynchronous OpenAI client with a LiteralAI client to create a conversational agent. 
-It utilizes LiteralAI's step decorators for structured logging and tool orchestration within a conversational flow. 
+This code integrates an asynchronous OpenAI client with a Literal AI client to create a conversational agent.
+It utilizes Literal AI's step decorators for structured logging and tool orchestration within a conversational flow.
 The agent can process user messages, make decisions on tool usage, and generate responses based on a predefined set of tools and a maximum iteration limit to prevent infinite loops.
 
 **This example demonstrates thread-based monitoring, allowing for detailed tracking and analysis of conversational threads.**

--- a/guides/github-cookbook/evaluation.mdx
+++ b/guides/github-cookbook/evaluation.mdx
@@ -7,7 +7,7 @@ You can find the code here: https://github.com/Chainlit/literal-cookbook/tree/ma
 
 - [Prompt Iteration with **Promptfoo**](https://github.com/Chainlit/literal-cookbook/tree/main/evaluation/typescript/prompt-iteration-promptfoo):
 Our cookbook shows how a developer can leverage the `promptfoo` library in TypeScript to
-compute similarity scores and persist the results of their experiments directly on Literal. 
+compute similarity scores and persist the results of their experiments directly on Literal AI.
 - [Context Relevancy with **Ragas**](https://github.com/Chainlit/literal-cookbook/tree/main/evaluation/python): our notebook experiments on an example RAG
 application to score context relevancy.
 

--- a/guides/guide-tag-scores-metadata.mdx
+++ b/guides/guide-tag-scores-metadata.mdx
@@ -2,7 +2,7 @@
 title: Tags, Scores and Metadata, when to use what?
 ---
 
-In Literal, you can add Tags, Scores and Metadata to units like Threads, Steps, Runs and Generations. What do they mean and when do you use which type? 
+In Literal AI, you can add Tags, Scores and Metadata to units like Threads, Steps, Runs and Generations. What do they mean and when do you use which type?
 
 ## Tags
 
@@ -96,7 +96,7 @@ main()
 
 #### 2. View Step Metadata in UI
 
-If you run the code above, you've created a thread with two steps. One step, the user query, has metadata attached. Let's view this in the Literal UI.
+If you run the code above, you've created a thread with two steps. One step, the user query, has metadata attached. Let's view this in the Literal AI UI.
 
 <Frame caption="Metadata view in Literal">
   <img src="/images/metadata-ui.png" alt="Metadata view in Literal" />

--- a/guides/rag-example.mdx
+++ b/guides/rag-example.mdx
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
 ## Logging the conversation with Literal
 
-First, we initialize the Literal client.
+First, we initialize the Literal AI client.
 <CodeGroup>
 ```python Python
 import os
@@ -148,7 +148,7 @@ client.flush_and_stop()
 
 ## Running the example in Python
 
-To run the example, you need to install the Literal client:
+To run the example, you need to install the Literal AI client:
 
 ```bash
 pip install literalai
@@ -160,7 +160,7 @@ Then, you can run the example:
 python example.py
 ```
 
-On the Literal platform, you will see the following thread being logged:
+On the Literal AI platform, you will see the following thread being logged:
 
 <Frame caption="Rendering of the Thread">
   <img src="/images/python-example.jpg" />

--- a/integrations/chainlit.mdx
+++ b/integrations/chainlit.mdx
@@ -5,6 +5,6 @@ title: "Chainlit"
 
 To start monitoring your Chainlit application, just set the `LITERAL_API_KEY` environment variable to your API key and run your application as you normally would.
 
-Literal will automatically start monitoring your application and send data to the Literal platform.
+Literal AI will automatically start monitoring your application and send data to the Literal AI platform.
 
-You **DO NOT** need to add any additional code, such as literal decorators or instrumentation, to your application to start monitoring it with Literal. 
+You **DO NOT** need to add any additional code, such as Literal AI decorators or instrumentation, to your application to start monitoring it with Literal AI.

--- a/integrations/llm-providers.mdx
+++ b/integrations/llm-providers.mdx
@@ -2,7 +2,7 @@
 title: "Anthropic, Mistral, etc."
 ---
 
-With Literal's integration capabilities, you can seamlessly monitor all the [providers](https://python.langchain.com/docs/integrations/platforms/) supported by Langchain. This allows for a unified observability experience across different AI models and services, ensuring that you can track and analyze the performance and usage of each provider within the Literal platform.
+With Literal's integration capabilities, you can seamlessly monitor all the [providers](https://python.langchain.com/docs/integrations/platforms/) supported by Langchain. This allows for a unified observability experience across different AI models and services, ensuring that you can track and analyze the performance and usage of each provider within the Literal AI platform.
 
 You can thus monitor Anthropic, Mistral, and many other LLM providers.
 

--- a/integrations/openai-assistant.mdx
+++ b/integrations/openai-assistant.mdx
@@ -2,7 +2,7 @@
 title: OpenAI Assistant
 ---
 
-You can sync your OpenAI Assistant threads with Literal in a few lines of code.
+You can sync your OpenAI Assistant threads with Literal AI in a few lines of code.
 
 <CodeGroup>
 ```ts TypeScript

--- a/integrations/openai.mdx
+++ b/integrations/openai.mdx
@@ -3,7 +3,7 @@ title: "OpenAI"
 ---
 
 
-You can use the Literal platform to instrument OpenAI API calls. This allows you to track and monitor the usage of the OpenAI API in your application and replay them in the Prompt Playground.
+You can use the Literal AI platform to instrument OpenAI API calls. This allows you to track and monitor the usage of the OpenAI API in your application and replay them in the Prompt Playground.
 
 <Check>The OpenAI instrumentation supports sync, async, streamed and regular responses!</Check>
 
@@ -15,7 +15,7 @@ import os
 from literalai import LiteralClient
 
 """
-You need to call the `instrument_openai` method from the Literal client to
+You need to call the `instrument_openai` method from the Literal AI client to
 enable the integration. Call it before any OpenAI API call.
 """
 literal_client = LiteralClient(api_key=os.getenv("LITERAL_API_KEY"))

--- a/python-client/api-reference/dataset.mdx
+++ b/python-client/api-reference/dataset.mdx
@@ -197,15 +197,15 @@ class DatasetItem:
 ```python
 dataset_item = sdk.api.create_dataset_item(
   dataset_id="dataset_id",
-  input={ "content": "What is Literal?" },
-  expected_output={ "content": "Literal is an observability solution." }
+  input={ "content": "What is Literal AI?" },
+  expected_output={ "content": "Literal AI is an observability solution." }
 )
 
 # Or directly through a Dataset
 dataset_item = dataset.create_item(
   dataset_id="dataset_id",
-  input={ "content": "What is Literal?" },
-  expected_output={ "content": "Literal is an observability solution." }
+  input={ "content": "What is Literal AI?" },
+  expected_output={ "content": "Literal AI is an observability solution." }
 )
 ```
 </CodeGroup>

--- a/python-client/api-reference/user.mdx
+++ b/python-client/api-reference/user.mdx
@@ -47,7 +47,7 @@ user = literal_client.api.get_user(id="<USER_UUID>")
 ```
 
 <ParamField path="id" type="uuid" required>
-  The Literal id of the user
+  The Literal AI id of the user
 </ParamField>
 
 ### Return type
@@ -63,7 +63,7 @@ updated_user = literal_client.api.update_user(id="<USER_UUID>", identifier="Jane
 ```
 
 <ParamField path="id" type="uuid" required>
-  The Literal id of the user
+  The Literal AI id of the user
 </ParamField>
 
 <ParamField path="identifier" type="string">
@@ -87,5 +87,5 @@ user = literal_client.api.delete_user(id="<USER_UUID>")
 ```
 
 <ParamField path="id" type="uuid" required>
-  The Literal id of the user
+  The Literal AI id of the user
 </ParamField>

--- a/python-client/get-started/introduction.mdx
+++ b/python-client/get-started/introduction.mdx
@@ -8,7 +8,7 @@ To install the Python client, run the following command:
 pip install literalai
 ```
 
-You can use the Literal Python client synchronous or asynchonous. For trying it out on small scale, you can use the synchronous version. If you move to production, you'll want to use asynchronous functions. All functions can be used both sync or async, except for functions on `Dataset`, which are always sync. All examples in the documentation are, for simplicity, using the synchronous client. If you want to use the async functions, make sure to `await` the functions.
+You can use the Literal AI Python client synchronous or asynchonous. For trying it out on small scale, you can use the synchronous version. If you move to production, you'll want to use asynchronous functions. All functions can be used both sync or async, except for functions on `Dataset`, which are always sync. All examples in the documentation are, for simplicity, using the synchronous client. If you want to use the async functions, make sure to `await` the functions.
 
 To instantiate the synchronous client:
 

--- a/self-hosting/deployment.mdx
+++ b/self-hosting/deployment.mdx
@@ -4,7 +4,7 @@ title: Manual Deployment
 
 <Note> This guide assumes you have a Docker Personal Access Token (PAT) to authenticate with the Docker registry. If you do not have a Docker PAT, please contact us [here](https://forms.gle/uyKyZmmpVET95Wbx8).</Note>
 
-You can deploy the LiteralAI platform anywhere by provisioning the infrastructure, setting up the environment variables and run the Docker image.
+You can deploy the Literal AI platform anywhere by provisioning the infrastructure, setting up the environment variables and run the Docker image.
 
 
 ## Get the Image
@@ -21,7 +21,7 @@ You can deploy the LiteralAI platform anywhere by provisioning the infrastructur
 
 ## Provision the Infrastructure
 
-To run the LiteralAI platform, you need to set up the following services:
+To run the Literal AI platform, you need to set up the following services:
 1. PostgreSQL database >= 15
 2. [Optional] File storage (AWS S3, Google Cloud Storage, Azure Blob Storage)
 3. [Optional] Redis cache
@@ -99,7 +99,7 @@ Either `REDIS_URL` or `REDISHOST` and `REDISPORT` can be used.
 | `REDISPORT` | Redis port. | `6379` |
 
 ### 5. SMTP Configuration [Optional]
-<Note>Setting up SMTP is optional. It enables Literal to send emails for password resets and project invitations.</Note>
+<Note>Setting up SMTP is optional. It enables Literal AI to send emails for password resets and project invitations.</Note>
 
 | Variable | Description | Example |
 |----------|-------------|---------|
@@ -116,4 +116,4 @@ The server within the Docker image runs on port `3000`. Ensure this port is expo
 
 ### Start the Container
 
-You should now be able to start the container and access the Literal Platform.
+You should now be able to start the container and access the Literal AI Platform.

--- a/self-hosting/get-started.mdx
+++ b/self-hosting/get-started.mdx
@@ -2,21 +2,21 @@
 title: Get Started
 ---
 
-Self hosting the LiteralAI platform requires a Docker Personal Access Token (PAT) to authenticate with the Docker registry.
-This token is used to pull the LiteralAI image from the registry.
+Self hosting the Literal AI platform requires a Docker Personal Access Token (PAT) to authenticate with the Docker registry.
+This token is used to pull the Literal AI image from the registry.
 
 To get your Docker PAT, please contact us [here](https://forms.gle/uyKyZmmpVET95Wbx8).
 
 ## Deploying the Image
 
-Once you have your Docker PAT, you are ready to deploy the LiteralAI platform. There are several options for hosting the platform:
+Once you have your Docker PAT, you are ready to deploy the Literal AI platform. There are several options for hosting the platform:
 
 <CardGroup cols={2}>
 <Card
   title="Azure"
   icon={<svg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg' fillRule='evenodd' clipRule='evenodd' strokeLinejoin='round' strokeMiterlimit='2'><g fillRule='nonzero'><path d='M52.091 10.225h40.684L50.541 135.361a6.5 6.5 0 01-6.146 4.412H12.732c-3.553 0-6.477-2.923-6.477-6.476 0-.704.115-1.403.34-2.07L45.944 14.638a6.501 6.501 0 016.147-4.415v.002z' fill='url(#prefix___Linear1)' transform='translate(2.076 1.626) scale(3.37462)'/><path d='M377.371 319.374H159.644c-5.527 0-10.076 4.549-10.076 10.077 0 2.794 1.164 5.466 3.206 7.37l139.901 130.577a21.986 21.986 0 0015.004 5.91H430.96l-53.589-153.934z' fill='#0078d4'/><path d='M52.091 10.225a6.447 6.447 0 00-6.161 4.498L6.644 131.12a6.457 6.457 0 00-.38 2.185c0 3.548 2.92 6.468 6.469 6.468H45.23a6.95 6.95 0 005.328-4.531l7.834-23.089 27.985 26.102a6.622 6.622 0 004.165 1.518h36.395l-15.962-45.615-46.533.011 28.48-83.944H52.091z' fill='url(#prefix___Linear2)' transform='translate(2.076 1.626) scale(3.37462)'/><path d='M104.055 14.631a6.492 6.492 0 00-6.138-4.406H52.575a6.493 6.493 0 016.138 4.406l39.35 116.594c.225.668.34 1.367.34 2.072 0 3.554-2.924 6.478-6.478 6.478h45.344c3.553-.001 6.476-2.925 6.476-6.478 0-.705-.115-1.404-.34-2.072l-39.35-116.594z' fill='url(#prefix___Linear3)' transform='translate(2.076 1.626) scale(3.37462)'/></g><defs><linearGradient id='prefix___Linear1' x1='0' y1='0' x2='1' y2='0' gradientUnits='userSpaceOnUse' gradientTransform='rotate(108.701 26.35 33.911) scale(131.7791)'><stop offset='0' stopColor='#114a8b'/><stop offset='1' stopColor='#0669bc'/></linearGradient><linearGradient id='prefix___Linear2' x1='0' y1='0' x2='1' y2='0' gradientUnits='userSpaceOnUse' gradientTransform='rotate(161.318 33.644 45.587) scale(10.31703)'><stop offset='0' stopOpacity='.3'/><stop offset='.07' stopOpacity='.2'/><stop offset='.32' stopOpacity='.1'/><stop offset='.62' stopOpacity='.05'/><stop offset='1' stopOpacity='0'/></linearGradient><linearGradient id='prefix___Linear3' x1='0' y1='0' x2='1' y2='0' gradientUnits='userSpaceOnUse' gradientTransform='rotate(69.426 25.69 62.036) scale(131.9816)'><stop offset='0' stopColor='#3ccbf4'/><stop offset='1' stopColor='#2892df'/></linearGradient></defs></svg>}
   href="">
-    Deploy the LiteralAI platform on Azure in a few minutes with the Azure Developer CLI.
+    Deploy the Literal AI platform on Azure in a few minutes with the Azure Developer CLI.
 </Card>
 
 <Card
@@ -39,13 +39,13 @@ Once you have your Docker PAT, you are ready to deploy the LiteralAI platform. T
   icon="docker"
   color="#0285c7"
   href="/self-hosting/deployment">
-  Deploy the LiteralAI platform anywhere. You will have to provision the infrastructure and deploy the Docker image.
+  Deploy the Literal AI platform anywhere. You will have to provision the infrastructure and deploy the Docker image.
 </Card>
 </CardGroup>
 
 ## Update the SDKs
 
-By default, the LiteralAI SDKs point to the cloud hosted version of the platform. To point the SDKs to your self-hosted platform you will have to update the `url` parameter in the SDK instantiation:
+By default, the Literal AI SDKs point to the cloud hosted version of the platform. To point the SDKs to your self-hosted platform you will have to update the `url` parameter in the SDK instantiation:
 
 <CodeGroup>
 ```python Python

--- a/typescript-client/api-reference/dataset.mdx
+++ b/typescript-client/api-reference/dataset.mdx
@@ -197,14 +197,14 @@ type DatasetItem = {
 
 ```typescript
 const datasetItem = await literalClient.api.createDatasetItem("dataset_id", {
-  input: { content: "What is Literal?" },
-  expectedOutput: { content: "Literal is an observability solution." },
+  input: { content: "What is Literal AI?" },
+  expectedOutput: { content: "Literal AI is an observability solution." },
 });
 
 # Or directly through a Dataset
 const datasetItem = await dataset.createDatasetItem("dataset_id", {
-  input: { content: "What is Literal?" },
-  expectedOutput: { content: "Literal is an observability solution." },
+  input: { content: "What is Literal AI?" },
+  expectedOutput: { content: "Literal AI is an observability solution." },
 });
 ```
 

--- a/typescript-client/introduction.mdx
+++ b/typescript-client/introduction.mdx
@@ -3,7 +3,7 @@ title: Installation
 ---
 
 <Note>
-  Check the Literal TypeScript Client on [NPM](https://www.npmjs.com/package/@literalai/client) for the documentation.
+  Check the Literal AI TypeScript Client on [NPM](https://www.npmjs.com/package/@literalai/client) for the documentation.
 </Note>
 
 ```shell


### PR DESCRIPTION
Let me know if I went too far with the renaming.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Chainlit/literal-docs/45)
<!-- Reviewable:end -->
