### PR TITLE
fix: python sdk version in release notes

### DIFF
--- a/more/release-notes.mdx
+++ b/more/release-notes.mdx
@@ -8,7 +8,7 @@ All changes and improvements to Literal AI are listed here. For changes in the S
 
 This version is compatible with:
 * [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.506` and above.
+* [Python SDK](/python-client) version `0.0.509` and above.
 * [TypeScript SDK](/typescript-client) version `0.0.503` and above.
 
 ### Breaking Changes
@@ -40,7 +40,7 @@ This version is compatible with:
 
 This version is compatible with:
 * [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.506` and above.
+* [Python SDK](/python-client) version `0.0.509` and above.
 * [TypeScript SDK](/typescript-client) version `0.0.503` and above.
 
 ### Breaking Changes
@@ -75,7 +75,7 @@ This version is compatible with:
 
 This version is compatible with:
 * [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.506` and above.
+* [Python SDK](/python-client) version `0.0.509` and above.
 * [TypeScript SDK](/typescript-client) version `0.0.503` and above.
 
 ### Breaking Changes
@@ -111,7 +111,7 @@ This version is compatible with:
 
 This version is compatible with:
 * [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.506` and above.
+* [Python SDK](/python-client) version `0.0.509` and above.
 * [TypeScript SDK](/typescript-client) version `0.0.503` and above.
 
 ### Breaking Changes


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Chainlit/literal-docs/56)
<!-- Reviewable:end -->
