### PR TITLE
docs: release notes for 0.0.611

### DIFF
--- a/more/release-notes.mdx
+++ b/more/release-notes.mdx
@@ -2,14 +2,35 @@
 title: Release Notes
 ---
 
+
 All changes and improvements to Literal AI are listed here. For changes in the SDKs, go to the [Python SDK](/python-client/development/changelog) or [TypeScript SDK](/typescript-client/development/changelog).
 
-# 0.0.610-beta (june 24, 2024)
 
-This version is compatible with:
+<Note>
+Literal AI cloud is currently compatible with:
 * [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
 * [Python SDK](/python-client) version `0.0.509` and above.
 * [TypeScript SDK](/typescript-client) version `0.0.503` and above.
+</Note>
+
+
+# 0.0.611-beta (July 1st, 2024)
+
+### New features
+
+* Easily navigate the Runs view with arrow keys
+* You can now filter Runs/Generations by score presence
+* You can now bulk add Generations to Datasets from the UI
+* Dark theme for the diff editor, box plots and toasters
+* Added a new "Run" chart to the dashboard
+
+### Improvements
+
+* This version embarks the first iteration of our UI revamp
+* Images are now zoomable in the Prompt Playground
+
+
+# 0.0.610-beta (June 24, 2024)
 
 ### Improvements
 
@@ -26,15 +47,6 @@ This version is compatible with:
 
 
 # 0.0.609-beta (June 17, 2024)
-
-This version is compatible with:
-* [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.509` and above.
-* [TypeScript SDK](/typescript-client) version `0.0.503` and above.
-
-### Breaking changes
-
-None
 
 ### New features
 
@@ -61,15 +73,6 @@ None
 
 
 # 0.0.608-beta (June 4, 2024)
-
-This version is compatible with:
-* [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.509` and above.
-* [TypeScript SDK](/typescript-client) version `0.0.503` and above.
-
-### Breaking changes
-
-None
 
 ### New features
 
@@ -104,15 +107,6 @@ None
 
 # 0.0.607-beta (May 27, 2024)
 
-This version is compatible with:
-* [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.509` and above.
-* [TypeScript SDK](/typescript-client) version `0.0.503` and above.
-
-### Breaking changes
-
-None
-
 ### New features
 
 * Added online evaluations to score LLM generations on the fly.
@@ -138,11 +132,6 @@ None
 * Newly created API keys do not contain special characters
 
 # 0.0.606-beta (May 20, 2024)
-
-This version is compatible with:
-* [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.509` and above.
-* [TypeScript SDK](/typescript-client) version `0.0.503` and above.
 
 ### Breaking Changes
 
@@ -171,15 +160,6 @@ This version is compatible with:
 
 # 0.0.605-beta (May 13, 2024)
 
-This version is compatible with:
-* [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.509` and above.
-* [TypeScript SDK](/typescript-client) version `0.0.503` and above.
-
-### Breaking Changes
-
-* None
-
 ### New Features
 
 * Support GPT-4o as LLM model provider
@@ -202,18 +182,7 @@ This version is compatible with:
 * Fix a bug where full-text searching threads would lead to a spike in cpu usage
 * Fix a rare bug that could occur when ingesting multiple steps with a new tag
 
-
-
 # 0.0.604-beta (May 6, 2024)
-
-This version is compatible with:
-* [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.509` and above.
-* [TypeScript SDK](/typescript-client) version `0.0.503` and above.
-
-### Breaking Changes
-
-* None
 
 ### New Features
 
@@ -238,19 +207,7 @@ This version is compatible with:
 
 * Fix dashboard evolution badge tooltip period being wrong
 
-
-
 # 0.0.603-beta (April 29, 2024)
-
-This version is compatible with:
-* [Chainlit](https://docs.chainlit.io/get-started/overview) version `1.0.504` and above.
-* [Python SDK](/python-client) version `0.0.509` and above.
-* [TypeScript SDK](/typescript-client) version `0.0.503` and above.
-
-### Breaking Changes
-
-* None
-
 
 ### New Features
 


### PR DESCRIPTION
In passing i removed the "Breaking changes > None" blocks in the individual notes.

I also removed the "Version compatibility" block which hadn't been updated since the first release note in the docs. I put it more prominently in a Callout at the top of the page.

![image](https://github.com/Chainlit/literal-docs/assets/1461760/c61c35cd-c062-4eef-b0e2-c3a2b23457f9)
